### PR TITLE
docker bash completion is not present in 0.5.3 source code

### DIFF
--- a/app-emulation/lxc-docker/lxc-docker-0.5.3.ebuild
+++ b/app-emulation/lxc-docker/lxc-docker-0.5.3.ebuild
@@ -61,9 +61,7 @@ src_install() {
 	
 	insinto /usr/share/${P}/contrib
 	doins contrib/README contrib/mkimage-*
-	cp -R "${S}/contrib"/{docker-build,vagrant-docker} "${D}/usr/share/${P}/contrib/"
-	
-	newbashcomp contrib/docker.bash docker
+	cp -R "${S}/contrib"/vagrant-docker "${D}/usr/share/${P}/contrib/"
 }
 
 pkg_postinst() {


### PR DESCRIPTION
Hello,
I guess it was introduced later.
