### PR TITLE
fix(docker.service): don't write-out a pid file

### DIFF
--- a/app-emulation/docker/files/docker.service
+++ b/app-emulation/docker/files/docker.service
@@ -6,7 +6,7 @@ After=multi-user.target
 [Service]
 Type=simple
 ExecStartPre=/bin/mount --make-rprivate /
-ExecStart=/usr/bin/docker -d -p /run/docker.pid
+ExecStart=/usr/bin/docker -d
 TimeoutSec=60
 
 [Install]


### PR DESCRIPTION
there is no reason to have a pid file on systemd. Remove it.
