### PR TITLE
feat(app-emulation/docker): setup CGO variables

### DIFF
--- a/app-emulation/docker/docker-0.7.0.ebuild
+++ b/app-emulation/docker/docker-0.7.0.ebuild
@@ -100,6 +100,10 @@ src_compile() {
 	# we need our vendored deps, too
 	export GOPATH="$GOPATH:$(pwd -P)/vendor"
 
+	# Gentoo doesn't set this up right yet
+	export CGO_CFLAGS="-I${ROOT}/usr/include"
+	export CGO_LDFLAGS="-L${ROOT}/usr/lib"
+
 	# time to build!
 	./hack/make.sh dynbinary || die
 


### PR DESCRIPTION
This change is needed if the build host isn't the same as the build target. emerge sets this up for gcc automatically but not Go.
